### PR TITLE
- fixed NullPointerException if there is no value associated for locationList

### DIFF
--- a/src/cmanager/LocationList.java
+++ b/src/cmanager/LocationList.java
@@ -36,8 +36,11 @@ public class LocationList
 	{
 		String base64 = Settings.getS(Settings.Key.LOCATION_LIST);
 		
-		ByteArrayInputStream bis = new ByteArrayInputStream(Base64.decodeBase64(base64));
-		locations = FileHelper.deserialize(bis, new ArrayList<Location>().getClass());
+		if(base64 != null)
+		{
+			ByteArrayInputStream bis = new ByteArrayInputStream(Base64.decodeBase64(base64));
+			locations = FileHelper.deserialize(bis, new ArrayList<Location>().getClass());
+		}
 	}
 	
 	public ArrayList<Location> getLocations()


### PR DESCRIPTION
I have never run cmanager before, so the prefs.xml file did not exist and I got this exception:

```
java -jar cm.jar 
Exception in thread "main" java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.eclipse.jdt.internal.jarinjarloader.JarRsrcLoader.main(JarRsrcLoader.java:58)
Caused by: java.lang.NullPointerException
    at java.io.ByteArrayInputStream.<init>(ByteArrayInputStream.java:106)
    at cmanager.LocationList.load(LocationList.java:39)
    at cmanager.LocationList.getLocations(LocationList.java:47)
    at cmanager.MainWindow.updateLocationCombobox(MainWindow.java:425)
    at cmanager.MainWindow.<init>(MainWindow.java:419)
    at cmanager.Main.main(Main.java:62)
    ... 5 more
```
