### PR TITLE
- use HTTPS for privacy and security reasons

### DIFF
--- a/src/cmanager/Geocache.java
+++ b/src/cmanager/Geocache.java
@@ -264,9 +264,9 @@ public class Geocache implements Serializable, Comparable<String>
 	
 	public String getURL(){
 		if( isGC() )
-			return "http://www.geocaching.com/geocache/" + code;
+			return "https://www.geocaching.com/geocache/" + code;
 		if( isOC() )
-			return "http://www.opencaching.de/" + code;
+			return "https://www.opencaching.de/" + code;
 		
 		return null;
 	}

--- a/src/cmanager/OKAPI.java
+++ b/src/cmanager/OKAPI.java
@@ -24,7 +24,7 @@ public class OKAPI
 	
 	public static String usernameToUUID(String username) throws Exception
 	{
-		String url = "http://www.opencaching.de/okapi/services/users/by_username" + 
+		String url = "https://www.opencaching.de/okapi/services/users/by_username" +
 				"?consumer_key=" + CONSUMER_API_KEY +
 				"&format=xmlmap2" + 
 				"&username=" + URLEncoder.encode(username, "UTF-8") +
@@ -52,7 +52,7 @@ public class OKAPI
 		ArrayList<Geocache> caches = new ArrayList<Geocache>();
 		
 		boolean useOAuth = excludeUUID != null;
-		String url = "http://www.opencaching.de/okapi/services/caches/search/nearest" + 
+		String url = "https://www.opencaching.de/okapi/services/caches/search/nearest" +
 			"?consumer_key=" + CONSUMER_API_KEY + 
 			"&format=xmlmap2" + 
 			"&center=" + lat.toString() + "|" + lon.toString() + 
@@ -101,7 +101,7 @@ public class OKAPI
 		if(index >= 0 )
 			return offlineStore.get(index);
 		
-		String http = HTTP.get("http://www.opencaching.de/okapi/services/caches/geocache"+
+		String http = HTTP.get("https://www.opencaching.de/okapi/services/caches/geocache"+
 			"?consumer_key="+ CONSUMER_API_KEY +
 			"&format=xmlmap2" + 
 			"&cache_code=" + code +
@@ -169,7 +169,7 @@ public class OKAPI
 	
 	public static Geocache completeCacheDetails(Geocache g) throws Exception 
 	{
-		String http = HTTP.get("http://www.opencaching.de/okapi/services/caches/geocache"+
+		String http = HTTP.get("https://www.opencaching.de/okapi/services/caches/geocache"+
 				"?consumer_key="+ CONSUMER_API_KEY +
 				"&format=xmlmap2" + 
 				"&cache_code=" + g.getCode() +
@@ -241,7 +241,7 @@ public class OKAPI
 	
 	public static String getUUID(OCUser user) throws MalFormedException, IOException
 	{
-		String url = "http://www.opencaching.de/okapi/services/users/user" +
+		String url = "https://www.opencaching.de/okapi/services/users/user" +
 				"?format=xmlmap2" + 
 				"&fields=uuid";
 		
@@ -262,7 +262,7 @@ public class OKAPI
 	
 	public static void postLog(OCUser user, Geocache cache, GeocacheLog log) throws MalFormedException, UnsupportedEncodingException
 	{
-		String url = "http://www.opencaching.de/okapi/services/logs/submit" +
+		String url = "https://www.opencaching.de/okapi/services/logs/submit" +
 				"?format=xmlmap2" + 
 				"&cache_code=" + URLEncoder.encode( cache.getCode(), "UTF-8") +
 				"&logtype=" + URLEncoder.encode("Found it", "UTF-8") +
@@ -284,7 +284,7 @@ public class OKAPI
 	{
 		String uuid = getUUID(user);
 		
-		String url = "http://www.opencaching.de/okapi/services/users/user" +
+		String url = "https://www.opencaching.de/okapi/services/users/user" +
 				"?format=xmlmap2" + 
 				"&fields=home_location" +
 				"&user_uuid=" + uuid;

--- a/src/cmanager/OKAPI_OAUTH.java
+++ b/src/cmanager/OKAPI_OAUTH.java
@@ -10,19 +10,19 @@ public class OKAPI_OAUTH extends DefaultApi10a
   @Override
   public String getAccessTokenEndpoint()
   {
-    return "http://www.opencaching.de/okapi/services/oauth/access_token";
+    return "https://www.opencaching.de/okapi/services/oauth/access_token";
   }
 
   @Override
   public String getRequestTokenEndpoint()
   {
-    return "http://www.opencaching.de/okapi/services/oauth/request_token";
+    return "https://www.opencaching.de/okapi/services/oauth/request_token";
   }
 
   @Override
   public String getAuthorizationUrl(Token requestToken)
   {
-    return String.format("http://www.opencaching.de/okapi/services/oauth/authorize?oauth_token=%s", 
+    return String.format("https://www.opencaching.de/okapi/services/oauth/authorize?oauth_token=%s",
     		requestToken.getToken());
   }
 }


### PR DESCRIPTION
User data and OKAPI secrets can be easily intercepted, using HTTPS will prevent this,
as the communication will be encrypted.

![http](https://cloud.githubusercontent.com/assets/1938536/13197944/40f36f1e-d7fc-11e5-8bc6-5cba7bf3721f.png)
