### PR TITLE
- fixed: cmanager would not quit properly after selecting 'Exit' from the menu

### DIFF
--- a/src/cmanager/MainWindow.java
+++ b/src/cmanager/MainWindow.java
@@ -104,7 +104,7 @@ public class MainWindow extends JFrame {
 		mntmExit.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent arg0) 
 			{
-				THIS.dispose();
+				THIS.dispatchEvent(new WindowEvent(THIS, WindowEvent.WINDOW_CLOSING));
 			}
 		});
 		


### PR DESCRIPTION
For me cmanager did not quit properly if using 'Menu -> Exit'.
Today I experienced this bug also on another computer, on a totally different Linux system.
This motivated me, to invest some time to figure out the problem.
I also found out that if I click the 'x' on the window frame, cmanager quits properly.
So there was a difference between these two ways of quitting cmanager.
